### PR TITLE
Add ngx.req.upstream_name() function

### DIFF
--- a/t/137-req-misc.t
+++ b/t/137-req-misc.t
@@ -60,3 +60,75 @@ GET /test
 --- response_body
 internal
 
+
+
+=== TEST 3: upstream_name with valid explicit upstream
+--- http_config
+    upstream some_upstream {
+        server 127.0.0.1:$TEST_NGINX_SERVER_PORT;
+    }
+--- config
+    log_by_lua_block {
+        ngx.log(ngx.INFO, "upstream = " .. tostring(ngx.req.upstream_name()))
+    }
+    location /test {
+        proxy_pass http://some_upstream/back;
+    }
+    location /back {
+        echo ok;
+    }
+--- request
+GET /test
+--- log_level: info
+--- error_log eval
+qr/upstream = some_upstream/
+
+
+
+=== TEST 4: upstream_name with valid implicit upstream
+--- config
+    log_by_lua_block {
+        ngx.log(ngx.INFO, "upstream = " .. tostring(ngx.req.upstream_name()))
+    }
+    location /test {
+        proxy_pass http://127.0.0.1:$TEST_NGINX_SERVER_PORT/back;
+    }
+    location /back {
+        echo ok;
+    }
+--- request
+GET /test
+--- log_level: info
+--- error_log eval
+qr/upstream = 127.0.0.1:\d+/
+
+
+
+=== TEST 5: upstream_name with no proxy_pass
+--- config
+    log_by_lua_block {
+        ngx.log(ngx.INFO, "upstream = " .. tostring(ngx.req.upstream_name()))
+    }
+    location /test {
+        echo ok;
+    }
+--- request
+GET /test
+--- log_level: info
+--- error_log eval
+qr/upstream = nil/
+
+
+
+=== TEST 6: upstream_name in content_by_lua
+--- config
+    location /test {
+        content_by_lua_block {
+            ngx.say(ngx.req.upstream_name())
+        }
+    }
+--- request
+GET /test
+--- response_body
+nil
+


### PR DESCRIPTION
This makes the current request's upstream available in phases after `proxy_pass` has occurred. This will allow us to include the upstream name in `log_by_lua`.

I think we should run this patch in production for a bit before submitting to upstream.

@PeiwenChen @csfrancis @Sirupsen for review

cc @agentzh does this make sense or is there an easier way that I'm missing?
